### PR TITLE
Add BMI parameter to WeightScaleMsg

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -4710,6 +4710,7 @@ type WeightScaleMsg struct {
 	MetabolicAge      uint8
 	VisceralFatRating uint8
 	UserProfileIndex  MessageIndex // Associates this weight scale message to a user.  This corresponds to the index of the user profile message in the weight scale file.
+	BodyMassIndex     uint16       // has to be divided by 10 to get the actual BMI value. e.g.: a value of 213 is actually a BMI of 21.3
 }
 
 // NewWeightScaleMsg returns a weight_scale FIT message
@@ -4729,6 +4730,7 @@ func NewWeightScaleMsg() *WeightScaleMsg {
 		MetabolicAge:      0xFF,
 		VisceralFatRating: 0xFF,
 		UserProfileIndex:  0xFFFF,
+		BodyMassIndex:     0xFFFF,
 	}
 }
 

--- a/profile.go
+++ b/profile.go
@@ -986,6 +986,7 @@ var _fields = [...][256]*field{
 		10:  {10, 10, types.Fit(2), 1},
 		11:  {11, 11, types.Fit(2), 1},
 		12:  {12, 12, types.Fit(4), 1},
+		13:  {13, 13, types.Fit(4), 1},
 	},
 
 	MesgNumBloodPressure: {


### PR DESCRIPTION
Hi @tormoder,

I'd like to add the BMI parameter to the WeightScaleMsg, due to the issue here: https://github.com/davidkroell/bodycomposition/issues/9

I've conducted a first integration test with my utility [davidkroell/bodycomposition](https://github.com/davidkroell/bodycomposition) and it works:

![grafik](https://user-images.githubusercontent.com/23698324/140046876-1216f6be-0fef-41bd-840d-373a3634a668.png)
(screenshot from Garmin Connect)

I wasn't able to fix the tests, could you help me out?

Regards,

David