### PR TITLE
include multi-byte bit in base type

### DIFF
--- a/internal/types/base.go
+++ b/internal/types/base.go
@@ -9,13 +9,25 @@ import (
 )
 
 const (
-	pkg           = "types"
-	typeNumMask   = 0x1F
-	multiByteFlag = 0x80
+	pkg         = "types"
+	typeNumMask = 0x1F
 )
 
 type Base byte
 
+type baseType struct {
+	size    int
+	name    string
+	signed  bool
+	integer bool
+	invalid interface{}
+	// for codegen
+	gotype    string
+	goinvalid string
+}
+
+// Base types for fit data.
+// The base 5 bits increase by 1 for each definition with all multi-byte number types having the MSB set.
 const (
 	BaseEnum    Base = 0x00
 	BaseSint8   Base = 0x01 // 2's complement format
@@ -36,12 +48,51 @@ const (
 	BaseUint64z Base = 0x90
 )
 
-func (t Base) index() byte {
-	return byte(t) & typeNumMask
-}
+// Internal compressed representation of certain base types.
+// With this, we can fit all base types in 5 bits as opposed to 8 bits.
+// Base types should be decompressed before use.
+const (
+	compressedSint16  byte = 0x03
+	compressedUint16  byte = 0x04
+	compressedSint32  byte = 0x05
+	compressedUint32  byte = 0x06
+	compressedFloat32 byte = 0x08
+	compressedFloat64 byte = 0x09
+	compressedUint16z byte = 0x0B
+	compressedUint32z byte = 0x0C
+	compressedSint64  byte = 0x0E
+	compressedUint64  byte = 0x0F
+	compressedUint64z byte = 0x10
+)
 
-func (t Base) multibyte() bool {
-	return (byte(t) & multiByteFlag) == multiByteFlag
+func decompress(b byte) Base {
+	b = b & typeNumMask
+	switch b {
+	case compressedSint16:
+		return BaseSint16
+	case compressedUint16:
+		return BaseUint16
+	case compressedSint32:
+		return BaseSint32
+	case compressedUint32:
+		return BaseUint32
+	case compressedFloat32:
+		return BaseFloat32
+	case compressedFloat64:
+		return BaseFloat64
+	case compressedUint16z:
+		return BaseUint16z
+	case compressedUint32z:
+		return BaseUint32z
+	case compressedSint64:
+		return BaseSint64
+	case compressedUint64:
+		return BaseUint64
+	case compressedUint64z:
+		return BaseUint64z
+	default:
+		return Base(b)
+	}
 }
 
 func (t Base) Float() bool {
@@ -49,19 +100,19 @@ func (t Base) Float() bool {
 }
 
 func (t Base) GoInvalidValue() string {
-	return binvalid[t.index()]
+	return t.baseType().goinvalid
 }
 
 func (t Base) GoType() string {
-	return bgotype[t.index()]
+	return t.baseType().gotype
 }
 
 func (t Base) Integer() bool {
-	return binteger[t.index()]
+	return t.baseType().integer
 }
 
 func (t Base) Known() bool {
-	return int(t.index()) < len(bname) && (t.multibyte() == (t.Size() > 1))
+	return t.baseType() != nil
 }
 
 func (t Base) PkgString() string {
@@ -69,165 +120,237 @@ func (t Base) PkgString() string {
 }
 
 func (t Base) Signed() bool {
-	return bsigned[t.index()]
+	return t.baseType().signed
 }
 
 func (t Base) Size() int {
-	return bsize[t.index()]
+	return t.baseType().size
 }
 
 func (t Base) String() string {
-	if t.Known() {
-		return bname[t.index()]
+	if b := t.baseType(); b != nil {
+		return b.name
 	}
 	return fmt.Sprintf("unknown (0x%X)", byte(t))
 }
 
 func (t Base) Invalid() interface{} {
-	if t.Known() {
-		return goinvalid[t.index()]
+	if b := t.baseType(); b != nil {
+		return b.invalid
 	}
 	return fmt.Sprintf("unknown (0x%X)", byte(t))
 }
 
-var bsize = [...]int{
-	1,
-	1,
-	1,
-	2,
-	2,
-	4,
-	4,
-	1,
-	4,
-	8,
-	1,
-	2,
-	4,
-	1,
-	8,
-	8,
-	8,
+var baseTypeEnum = baseType{
+	name:      "BaseEnum",
+	size:      1,
+	integer:   false,
+	signed:    false,
+	invalid:   byte(0xFF),
+	gotype:    "byte",
+	goinvalid: "0xFF",
 }
 
-var bname = [...]string{
-	"BaseEnum",
-	"BaseSint8",
-	"BaseUint8",
-	"BaseSint16",
-	"BaseUint16",
-	"BaseSint32",
-	"BaseUint32",
-	"BaseString",
-	"BaseFloat32",
-	"BaseFloat64",
-	"BaseUint8z",
-	"BaseUint16z",
-	"BaseUint32z",
-	"BaseByte",
-	"BaseSint64",
-	"BaseUint64",
-	"BaseUint64z",
+var baseTypeSint8 = baseType{
+	name:      "BaseSint8",
+	size:      1,
+	integer:   true,
+	signed:    true,
+	invalid:   int8(0x7F),
+	gotype:    "int8",
+	goinvalid: "0x7F",
 }
 
-var binteger = [...]bool{
-	false,
-	true,
-	true,
-	true,
-	true,
-	true,
-	true,
-	false,
-	false,
-	false,
-	true,
-	true,
-	true,
-	false,
-	true,
-	true,
-	true,
+var baseTypeUint8 = baseType{
+	name:      "BaseUint8",
+	size:      1,
+	integer:   true,
+	signed:    false,
+	invalid:   uint8(0xFF),
+	gotype:    "uint8",
+	goinvalid: "0xFF",
 }
 
-var bsigned = [...]bool{
-	false,
-	true,
-	false,
-	true,
-	false,
-	true,
-	false,
-	false,
-	true,
-	true,
-	false,
-	false,
-	false,
-	false,
-	true,
-	false,
-	false,
+var baseTypeSint16 = baseType{
+	name:      "BaseSint16",
+	size:      2,
+	integer:   true,
+	signed:    true,
+	invalid:   int16(0x7FFF),
+	gotype:    "int16",
+	goinvalid: "0x7FFF",
 }
 
-var bgotype = [...]string{
-	"byte",
-	"int8",
-	"uint8",
-	"int16",
-	"uint16",
-	"int32",
-	"uint32",
-	"string",
-	"float32",
-	"float64",
-	"uint8",
-	"uint16",
-	"uint32",
-	"byte",
-	"int64",
-	"uint64",
-	"uint64",
+var baseTypeUint16 = baseType{
+	name:      "BaseUint16",
+	size:      2,
+	integer:   true,
+	signed:    false,
+	invalid:   uint16(0xFFFF),
+	gotype:    "uint16",
+	goinvalid: "0xFFFF",
 }
 
-var binvalid = [...]string{
-	"0xFF",
-	"0x7F",
-	"0xFF",
-	"0x7FFF",
-	"0xFFFF",
-	"0x7FFFFFFF",
-	"0xFFFFFFFF",
-	"\"\"",
-	"0xFFFFFFFF",
-	"0xFFFFFFFFFFFFFFFF",
-	"0x00",
-	"0x0000",
-	"0x00000000",
-	"0xFF",
-	"0x7FFFFFFFFFFFFFFF",
-	"0xFFFFFFFFFFFFFFFF",
-	"0x0000000000000000",
+var baseTypeSint32 = baseType{
+	name:      "BaseSint32",
+	size:      4,
+	integer:   true,
+	signed:    true,
+	invalid:   int32(0x7FFFFFFF),
+	gotype:    "int32",
+	goinvalid: "0x7FFFFFFF",
 }
 
-var goinvalid = [...]interface{}{
-	byte(0xFF),
-	int8(0x7F),
-	uint8(0xFF),
-	int16(0x7FFF),
-	uint16(0xFFFF),
-	int32(0x7FFFFFFF),
-	uint32(0xFFFFFFFF),
-	string(""),
-	math.Float32frombits(0xFFFFFFFF),
-	math.Float64frombits(0xFFFFFFFFFFFFFFFF),
-	uint8(0x00),
-	uint16(0x0000),
-	uint32(0x00000000),
-	byte(0xFF),
-	int64(0x7FFFFFFFFFFFFFFF),
-	uint64(0xFFFFFFFFFFFFFFFF),
-	uint64(0x0000000000000000),
+var baseTypeUint32 = baseType{
+	name:      "BaseUint32",
+	size:      4,
+	integer:   true,
+	signed:    false,
+	invalid:   uint32(0xFFFFFFFF),
+	gotype:    "uint32",
+	goinvalid: "0xFFFFFFFF",
+}
+
+var baseTypeString = baseType{
+	name:      "BaseString",
+	size:      1, // size doesn't really apply here
+	integer:   false,
+	signed:    false,
+	invalid:   string(""),
+	gotype:    "string",
+	goinvalid: "\"\"",
+}
+
+var baseTypeFloat32 = baseType{
+	name:      "BaseFloat32",
+	size:      4,
+	integer:   false,
+	signed:    true,
+	invalid:   math.Float32frombits(0xFFFFFFFF),
+	gotype:    "float32",
+	goinvalid: "0xFFFFFFFF",
+}
+
+var baseTypeFloat64 = baseType{
+	name:      "BaseFloat64",
+	size:      8,
+	integer:   false,
+	signed:    true,
+	invalid:   math.Float64frombits(0xFFFFFFFFFFFFFFFF),
+	gotype:    "float64",
+	goinvalid: "0xFFFFFFFFFFFFFFFF",
+}
+
+var baseTypeUint8z = baseType{
+	name:      "BaseUint8z",
+	size:      1,
+	integer:   true,
+	signed:    false,
+	invalid:   uint8(0x00),
+	gotype:    "uint8",
+	goinvalid: "0x00",
+}
+
+var baseTypeUint16z = baseType{
+	name:      "BaseUint16z",
+	size:      2,
+	integer:   true,
+	signed:    false,
+	invalid:   uint16(0x0000),
+	gotype:    "uint16",
+	goinvalid: "0x0000",
+}
+
+var baseTypeUint32z = baseType{
+	name:      "BaseUint32z",
+	size:      4,
+	integer:   true,
+	signed:    false,
+	invalid:   uint32(0x00000000),
+	gotype:    "uint32",
+	goinvalid: "0x00000000",
+}
+
+var baseTypeByte = baseType{
+	name:      "BaseByte",
+	size:      1,
+	integer:   false,
+	signed:    false,
+	invalid:   byte(0xFF),
+	gotype:    "byte",
+	goinvalid: "0xFF",
+}
+
+var baseTypeSint64 = baseType{
+	name:      "BaseSint64",
+	size:      8,
+	integer:   true,
+	signed:    true,
+	invalid:   int64(0x7FFFFFFFFFFFFFFF),
+	gotype:    "int64",
+	goinvalid: "0x7FFFFFFFFFFFFFFF",
+}
+
+var baseTypeUint64 = baseType{
+	name:      "BaseUint64",
+	size:      8,
+	integer:   true,
+	signed:    false,
+	invalid:   uint64(0xFFFFFFFFFFFFFFFF),
+	gotype:    "uint64",
+	goinvalid: "0xFFFFFFFFFFFFFFFF",
+}
+
+var baseTypeUint64z = baseType{
+	name:      "BaseUint64z",
+	size:      8,
+	integer:   true,
+	signed:    false,
+	invalid:   uint64(0x0000000000000000),
+	gotype:    "uint64",
+	goinvalid: "0x0000000000000000",
+}
+
+func (t Base) baseType() *baseType {
+	switch t {
+	case BaseEnum:
+		return &baseTypeEnum
+	case BaseSint8:
+		return &baseTypeSint8
+	case BaseUint8:
+		return &baseTypeUint8
+	case BaseSint16:
+		return &baseTypeSint16
+	case BaseUint16:
+		return &baseTypeUint16
+	case BaseSint32:
+		return &baseTypeSint32
+	case BaseUint32:
+		return &baseTypeUint32
+	case BaseString:
+		return &baseTypeString
+	case BaseFloat32:
+		return &baseTypeFloat32
+	case BaseFloat64:
+		return &baseTypeFloat64
+	case BaseUint8z:
+		return &baseTypeUint8z
+	case BaseUint16z:
+		return &baseTypeUint16z
+	case BaseUint32z:
+		return &baseTypeUint32z
+	case BaseByte:
+		return &baseTypeByte
+	case BaseSint64:
+		return &baseTypeSint64
+	case BaseUint64:
+		return &baseTypeUint64
+	case BaseUint64z:
+		return &baseTypeUint64z
+	default:
+		// XXX how careful should we be about nil pointers?
+		return nil
+	}
 }
 
 func BaseFromString(s string) (Base, error) {

--- a/internal/types/fit.go
+++ b/internal/types/fit.go
@@ -88,7 +88,7 @@ func (f Fit) Array() bool {
 func (f Fit) BaseType() Base {
 	t := Base(f & typeNumMask)
 	if t.Size() > 1 {
-		return Base(t | multiByteFlag)
+		return t | multiByteFlag
 	}
 	return t
 }

--- a/internal/types/fit.go
+++ b/internal/types/fit.go
@@ -86,7 +86,11 @@ func (f Fit) Array() bool {
 }
 
 func (f Fit) BaseType() Base {
-	return Base(f & 0x1F)
+	t := Base(f & typeNumMask)
+	if t.Size() > 1 {
+		return Base(t | multiByteFlag)
+	}
+	return t
 }
 
 func (f Fit) Valid() bool {

--- a/internal/types/fit.go
+++ b/internal/types/fit.go
@@ -86,11 +86,7 @@ func (f Fit) Array() bool {
 }
 
 func (f Fit) BaseType() Base {
-	t := Base(f & typeNumMask)
-	if t.Size() > 1 {
-		return t | multiByteFlag
-	}
-	return t
+	return decompress(byte(f))
 }
 
 func (f Fit) Valid() bool {

--- a/reader.go
+++ b/reader.go
@@ -453,7 +453,7 @@ func (d *decoder) parseDefinitionMessage(recordHeader byte) (*defmsg, error) {
 	for i, fd := range dm.fieldDefs {
 		fd.num = d.tmp[i*3]
 		fd.size = d.tmp[(i*3)+1]
-		fd.btype = types.DecodeBase(d.tmp[(i*3)+2])
+		fd.btype = types.Base(d.tmp[(i*3)+2])
 		if err = d.validateFieldDef(dm.globalMsgNum, fd); err != nil {
 			if d.debug {
 				d.opts.logger.Println("illegal definition message:", dm)

--- a/writer_internal_test.go
+++ b/writer_internal_test.go
@@ -481,8 +481,8 @@ func TestWriteDefMesg(t *testing.T) {
 		byte(MesgNumFileId & 0xFF), byte(MesgNumFileId >> 8),
 		3,
 		0, 1, 0,
-		1, 2, 4,
-		2, 2, 4,
+		1, 2, 132,
+		2, 2, 132,
 	}
 
 	if !bytes.Equal(buf.Bytes(), expect) {


### PR DESCRIPTION
The most-significant bit in the base type field is set on data types which are larger than 1 byte. While this bit isn't terribly important when parsing a fit file (and is all but ignored currently), it should still be set when exporting a fit file to prevent writing invalid base data types.

The updated values can be found [here](https://developer.garmin.com/fit/protocol/) under `Table 7. FIT Base Types and Invalid Values`