### PR TITLE
CONTRIBUTING: Add documentation for how to add a test FIT file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,24 @@ when filing an issue.
 
 Please follow standard Go conventions and make sure that invoking ```make``` in
 the root directory reports no errors.
+
+## Adding test FIT files
+
+When contributing a change to the parsing of FIT files it is beneficial to
+include a FIT file which causes the issue you have resolved. To ensure the
+FIT file is executed during tests you must do the following:
+
+Include the FIT file in an appropriate subdirectory of "testdata" such as
+"misc".
+
+Add an entry to decodeTestFiles in the file reader_files_test.go, ensuring
+that the fingerprint field is set to "1".
+
+Execute ```go test -update``` to calculate the fingerprint and update it. This
+will also produce a gzipped golden test output file in the same directory as
+your original file. This file can be inspected by using a tool like ```zcat```.
+
+Execute ```make test``` and ensure all tests have passed.
+
+Commit your newly added FIT file, the generated gzipped golden test output
+file, and the reader_files_test.go file.


### PR DESCRIPTION
This change updates the CONTRIBUTING file with documentation on how to also add test FIT files, based on my own recent experience. This can then be referenced in the future.